### PR TITLE
Added Forgot Password API

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,5 +1,5 @@
 const express=require('express');
-const {  signupUser,validationRegistration,validationLogin, loginUser} = require('../controllers/authController');
+const {  signupUser,validationRegistration,forgetPassword,validationLogin, loginUser} = require('../controllers/authController');
 const rateLimit=require('express-rate-limit')
 
 const router=express.Router();
@@ -15,6 +15,8 @@ const limiter=rateLimit({
 
 router.post("/create-account",limiter,validationRegistration,signupUser)
 router.post("/login-account",limiter,validationLogin,loginUser)
+router.post('/forget-password',forgetPassword)
+
 
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,6 @@
 const express=require('express');
 const dotenv=require('dotenv').config();
 const bodyParser=require('body-parser');
-// const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const session=require('express-session')
 const app=express();
 app.use(bodyParser.json())


### PR DESCRIPTION
## What I did

- Implemented forgot password API
- Added route `/user/forgot-password`
- Generates a password reset token and saves it in the database
- Returns a success response upon valid email

## How to test

1. Run `npm start` inside the backend folder
2. Send a `POST` request to `/user/forget-password` with the following body:

```json
{
  "email_address": "user@example.com"
}
