### PR TITLE
Added Delete Account API

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -291,6 +291,30 @@ const signupUser=async(req,res)=>{
         res.status(200).json({ message: 'Logged out successfully' });
       };
       
+      const deleteAccount=async(req,res)=>{
+        const userId = req.user.id;        
+ 
+        try{
+          const delAccount=await User.findOne({where:{
+            id:userId
+          }});
+          if(!delAccount){
+            res.status(400).send("Error 400 status code");
+          }
+          else{
+            await delAccount.destroy();
+            res.status(200).send("User-Account deleted successfully")
+          }
+
+        }
+        catch (err) {
+          console.error("Error on reset the password:", err);
+          return res.status(500).json({
+            success: false,
+            message: "Internal Server Error",
+          });
+        }
+      }
       
 
 
@@ -300,5 +324,5 @@ const signupUser=async(req,res)=>{
 
   
 
-module.exports={signupUser,loginUser,  forgetPassword,
+module.exports={signupUser,loginUser, deleteAccount, forgetPassword,
   resetPassword, logoutUser,validationRegistration,validationLogin}

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,6 +1,7 @@
 const express=require('express');
-const {  signupUser,validationRegistration,logoutUser,resetPassword,forgetPassword,validationLogin, loginUser} = require('../controllers/authController');
-const rateLimit=require('express-rate-limit')
+const {  signupUser,validationRegistration,deleteAccount,logoutUser,resetPassword,forgetPassword,validationLogin, loginUser} = require('../controllers/authController');
+const rateLimit=require('express-rate-limit');
+const { protectedRoutes } = require('../middlewares/protectedRoutes');
 
 const router=express.Router();
 
@@ -18,6 +19,7 @@ router.post("/login-account",limiter,validationLogin,loginUser)
 router.post('/forget-password',forgetPassword)
 router.get("/reset-password",resetPassword)
 router.post('/logout', logoutUser);
+router.delete('/delete-account',protectedRoutes,deleteAccount)
 
 
 


### PR DESCRIPTION
This API endpoint allows an authenticated user to delete their own account. The deletion is authorized **only if the user is logged in**, ensuring that users can remove only their own data. Upon successful deletion:
- The user’s account is removed from the database.
- All associated notes created by the user are also deleted.

## Endpoint
`DELETE /user/delete-account`

## Request

- **Headers:**
  - `Authorization: Bearer <token>`

## Response

### Success (200 OK)
```
User-Account deleted successfully
```

## Error Responses

## 401 Unauthorized
```json
{
 "message": "Invalid token"
}

```

## 404 Not Found
```
  Error 400 status code
```

## 500 Internal Server Error
```json
{
  "success": false,
  "message": "Internal Server Error"
}
```

## Features

- Authenticates the user via JWT token.
- Ensures only the logged-in user can delete their own account.
- Performs cascading delete of all notes related to the user.
- Returns clear and consistent success and error messages.

## Testing

- Tested with valid and invalid JWT tokens.
- Verified that only the requesting user's data is deleted.
- Ensured that all associated notes are removed from the database.
- Proper error handling tested for missing user, token, and internal errors.