### PR TITLE
Added fetch-single-note API

### DIFF
--- a/backend/controllers/notesController.js
+++ b/backend/controllers/notesController.js
@@ -1,5 +1,6 @@
 const db=require('../config/database')
 const Note=db.notes
+const User=db.user
 
 
 const createNotes = async (req, res) => {
@@ -111,7 +112,45 @@ const createNotes = async (req, res) => {
   }
 
 
+  const getSingleNote = async (req, res) => {
+    try {
+      const id = req.params.id;
+      const userId = req.user.id;
+  
+      const getOneNote = await Note.findOne({
+        where: {
+          id,
+          userId: userId, 
+        },
+        include:[{
+            model:User,
+            as:'user',
+            attributes:['full_name','email_address'],
+        }],
+
+      });
+  
+      if (!getOneNote) {
+        return res.status(404).json({ message: "Note not available of this ID" });
+      }
+  
+      return res.status(200).json({
+        message: `Note of ID ${id} fetched successfully`,
+        data: getOneNote,
+      });
+  
+    } catch (err) {
+      console.error("Fetch single note error:", err);
+      return res.status(500).json({
+        success: false,
+        message: "Internal Server Error",
+      });
+    }
+  };
+
+
+
   
 
-module.exports={createNotes,fetchAllNotes,updateNote, deleteNote}
+module.exports={createNotes,fetchAllNotes,updateNote,getSingleNote, deleteNote}
   

--- a/backend/routes/notesRoutes.js
+++ b/backend/routes/notesRoutes.js
@@ -1,6 +1,6 @@
 const express=require('express');
 const { protectedRoutes } = require('../middlewares/protectedRoutes');
-const { createNotes,fetchAllNotes, deleteNote,updateNote} = require('../controllers/notesController');
+const { createNotes,getSingleNote,fetchAllNotes, deleteNote,updateNote} = require('../controllers/notesController');
 const rateLimit=require('express-rate-limit')
 
 const router=express.Router();
@@ -28,5 +28,7 @@ router.post("/create-note",notesLimiter,protectedRoutes,createNotes)
 router.get("/fetch-all-notes",protectedRoutes,fetchAllNotes)
 router.put("/edit-note/:id",editnotesLimiter,protectedRoutes,updateNote)
 router.delete("/remove-note/:id",protectedRoutes,deleteNote)
+router.get("/get-single-note/:id",protectedRoutes,getSingleNote)
+
 
 module.exports = router;


### PR DESCRIPTION
This API endpoint allows an authenticated user to fetch a specific note by its ID. The note is only returned if it belongs to the requesting user, ensuring privacy and access control. The response includes associated user details like `full_name` and `email_address`.

## Endpoint
`GET /user/get-single-note/:id`

## Request

- **Headers:**
  - `Authorization: Bearer <token>`

- **Params:**
  - `id` (string): Unique identifier of the note to fetch.

## Response

### Success (200 OK)
```json
{
  "message": "Note of ID <id> fetched successfully",
  "data": {
    "id": "uuid",
    "title": "Note Title",
    "content": "Note content here...",
    "user": {
      "full_name": "John Doe",
      "email_address": "john@example.com"
    }
  }
}
```

## Error Responses
## 404 Not Found
```json
{
  "message": "Note not available of this ID"
}
```

## 401 Unauthorized
```json
{
 "message": "Invalid token"
}
```

## 500 Internal Server Error
```json
{
  "success": false,
  "message": "Internal Server Error"
}
```

## Features
- Authenticates user using JWT.
- Ensures only the owner of the note can fetch it.
- Includes associated user details in the response.
- Provides meaningful error messages and HTTP status codes.

## Testing
- Tested with valid and invalid note IDs.
- Verified that unauthorized users cannot access others' notes.
- Checked token validation and error handling for edge cases.